### PR TITLE
Handle ipython %magic black formatting errors.

### DIFF
--- a/clean_ipynb/cli.py
+++ b/clean_ipynb/cli.py
@@ -1,9 +1,10 @@
-import plac
 import glob
+from pathlib import Path
+
+import plac
 from wasabi import Printer
-from pathlib import Path
+
 from .clean_ipynb import clean_ipynb, clean_py
-from pathlib import Path
 
 msg = Printer()
 


### PR DESCRIPTION
Also fixed a missing import and cleaned up import order using isort.
Mainly resolves the issue that black cannot deal with IPython %magic (as it is not valid Python code) by commenting it out temporarily.