### PR TITLE
Added support for multiple paths. Replaced plac with argparse.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ### Clean IPYNB/PY
-Small CLI program capable of cleaning ```.ipynb``` and ```.py``` source. Tidy and remove redundant imports (via [autoflake](https://github.com/myint/autoflake)), sort imports (via [isort](https://github.com/timothycrosley/isort)), lint and standardize (via [black](https://github.com/ambv/black)). Apply equally to entire ```.py``` or ```.ipynb``` files. Additionally, clear all ```.ipynb``` cell outputs and execution counts (squeeze those diffs!). Forked from KwatMe's orginal [repo](https://github.com/KwatME/clean_ipynb).
+Small CLI program capable of cleaning ```.ipynb``` and ```.py``` sources. Tidy and remove redundant imports (via [autoflake](https://github.com/myint/autoflake)), sort imports (via [isort](https://github.com/timothycrosley/isort)), lint and standardize (via [black](https://github.com/ambv/black)). Apply equally to entire ```.py``` or ```.ipynb``` files. Additionally, clear all ```.ipynb``` cell outputs and execution counts (squeeze those diffs!). Forked from KwatMe's orginal [repo](https://github.com/KwatME/clean_ipynb).
 
 ### 1.0 Up and Running
 Via git pip:
@@ -30,9 +30,14 @@ Or an entire directory recursively:
 clean_ipynb <some_dir_containing_py_ipynb_source>
 ```
 
-Clean with specific features if necessary (uses all features by default):
+Or a list of files and directories:
 ```sh
-clean_ipynb <some_dir_containing_py_ipynb_source> -no-black -no-autoflake
+clean_ipynb a_single_script.py <some_dir_containing_py_ipynb_source>
+```
+
+Clean without specific features if necessary (uses all features by default):
+```sh
+clean_ipynb <some_dir_containing_py_ipynb_source> --no-black --no-autoflake
 ```
 
 A full list of parameters can be found via:
@@ -44,4 +49,5 @@ clean_ipynb --help
 * **Unit tests.** Null parameter, invalid parameter edge cases etc.
 * **Reimplement sub-command arg parsing.** Parse specific black/autoflake/isort args to main CLI.
 * **Remove subprocess calls.** Reach into subprograms, natively use without subprocess calls.
-* **Autoflake for ipynb sources.** Keep imported modules which are not used immediately in the cell they are imported in. The current default behaviour is problematic when imports are re-used throughout a notebook but only defined once in a cell dedicated just to this. Current workaround: use the flags `-no-py -no-autoflake` for jupyter notebooks, and `-no-ipynb` for python files (to avoid repeat operations when applied to directories).
+* **Autoflake for ipynb sources.** Keep module imports which are only used in other cells. This will require awareness of all code cells at once for the application of autoflake. Current workaround: use the flags `--no-py --no-autoflake` for Jupyter notebooks, and `--no-ipynb` for Python files (to avoid repeat operations when applied to identical inputs for both sets of flags).
+* **Read from standard input and write to standard output.** Exhibit behaviour analogous to other tools such as [black](https://github.com/ambv/black) which do this if `-` is used as a filename.

--- a/clean_ipynb/cli.py
+++ b/clean_ipynb/cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from wasabi import Printer
 
+from . import VERSION
 from .clean_ipynb import clean_ipynb, clean_py
 
 msg = Printer()
@@ -50,7 +51,14 @@ def main(
 
 
 def main_wrapper():
-    parser = argparse.ArgumentParser(description="Clean .py and .ipynb files.")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Tidy and remove redundant imports (via autoflake), sort imports (via "
+            "isort), lint and standardize (via black). Apply equally to entire .py or "
+            ".ipynb files, or directories containing such files. Additionally, clear "
+            "all .ipynb cell outputs and execution counts (squeeze those diffs!)."
+        )
+    )
     parser.add_argument("path", nargs="+", help="File(s) or dir(s) to clean")
     parser.add_argument("-p", "--no-py", help="Ignore .py sources", action="store_true")
     parser.add_argument(
@@ -70,6 +78,13 @@ def main_wrapper():
         "--keep-output",
         help="Do not clear jupyter notebook output",
         action="store_true",
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        help=f"Show the %(prog)s version number",
+        action="version",
+        version=f"%(prog)s {VERSION}",
     )
     args = parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
     packages=find_packages(),
     entry_points={"console_scripts": ["clean_ipynb=clean_ipynb.cli:main_wrapper"]},
     python_requires=">=3.6",
-    install_requires=("black", "wasabi", "isort", "jupyter", "autoflake", "plac"),
+    install_requires=("black", "wasabi", "isort", "jupyter", "autoflake"),
 )


### PR DESCRIPTION
Changes:
- I could not find a way to support multiple input paths using plac, so I rewrote the argument parsing using argparse to support this (if this is possible using plac, I would be happy to implement it if you would rather not switch away from plac).
- The long options have been made more consistent; previously, long options like '-no-autoflake' had only one leading dash, while the '--help' option had two (this change would also be possible using plac).
- Short options have been added (again, also possible using plac).
- The plac dependency has been removed.
- The README has been updated to reflect the new features and syntax.
- There is an additional TODO entry regarding stdin & stdout interaction.