### PR TITLE
Added error reporting for custom tools & Fix not working CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ clean_ipynb --help
 - Important to note:
   - Generic Tools mentioned in `json` are done in order, so you can decide which order to run formatters (this is enabled through ordered dicts)
     - This ensures that your tools are used in the order you specified (Except for `black` & `isort` which if active, will always be run at first in order `black`, `isort`)
-    - And the
   - If conflicting configurations are specified in flags & `json` (Ex: for which formatter to use `black` or `yapf`), the one in `json` takes precedence
 
 #### JSON Format

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ clean_ipynb --help
 ### 3.0 Features
 
 - Added support for generic tooling i.e, use any tool for python code 
+- Make sure that tool when used along with arguments doesn't output to stderr when no errors have occured. Ex: `black` does this, we need to use `-q` flag to stop it from doing so
 - It is reqired that the `command` when passed with `args` takes input from stdin & returns output in stdout, else your file wont get updated by tool
 - Use of generic is supported by using `JSON`
   - `-j` or `--tools-json` flag is used to provide `json`

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Ex: If you want to use `autopep8` instead of `black`
 {
     "black": {
         "command": "black",
-        "args": ["-"],
+        "args": ["-q", "-"],
         "active": false
     },
     "autopep8": {

--- a/clean_ipynb/cli.py
+++ b/clean_ipynb/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import glob
 from pathlib import Path
+from json import dumps
 
 from wasabi import Printer
 
@@ -124,7 +125,7 @@ def main_wrapper():
         # Enable yapf in json
         json_create_helper_dict['yapf'] = {
             "command": "yapf",
-            "args": ['-'],
+            "args": [],
             "active": True
         }
 
@@ -139,12 +140,12 @@ def main_wrapper():
             with open(args.tools_json, 'r') as f:
                 user_tools_with_pipe = load(f)
             json_create_helper_dict = {**json_create_helper_dict, **user_tools_with_pipe}
-            json_final = dumps(json_create_helper_dict)
         else:
             # json directly provided as string
             user_tools_with_pipe = loads(tools_json)
             json_create_helper_dict = {**json_create_helper_dict, **user_tools_with_pipe}
-            json_final = dumps(json_create_helper_dict)
+
+    json_final = dumps(json_create_helper_dict)
 
     for path in args.path:
         main(


### PR DESCRIPTION
Sorry for the inconvenience caused, the previous [pr](https://github.com/KwatME/clean_ipynb/pull/10) wasn't working for generic tools.
My testing was incorrect. It is failing with all the tools (including yapf). 

I thought yapf is working because code was formatted. But it actually was formatted with black. In cli, `json_final` was not updating due to misplacement of statement in if/else when it should not be.
And even after fixing it yapf failed. I debugged it by adding error reporting when command outputs to stderr. The problem was in the way of passing code to  pipe.

The fix is [here](https://github.com/kishansairam9/clean_ipynb/tree/add_error_reporting_for_custom_tools). This is of **high priority** (since 3.0 is not working) please merge pr fast. @KwatME 