### PR TITLE
Fix issue where FileNotFoundError is not caught during Julia check

### DIFF
--- a/clean_ipynb/has_julia_and_juliaformatter.py
+++ b/clean_ipynb/has_julia_and_juliaformatter.py
@@ -9,6 +9,6 @@ def has_julia_and_juliaformatter():
 
         return True
 
-    except CalledProcessError:
+    except (CalledProcessError, FileNotFoundError):
 
         return False


### PR DESCRIPTION
This fixes the issue where the julia check is failing because of an uncaught FileNotFound exception.

My Setup
```
- MacOS
- Python 3.7.4
- Pipenv virtualenv
- No julia binary installed
```

On version 1.0.0 and also current Master I get the following:
```
Traceback (most recent call last):
  File "/Users/madhavajay/.local/share/virtualenvs/identification-fk5tnlmm/bin/clean_ipynb", line 8, in <module>
    sys.exit(cli())
  File "/Users/madhavajay/.local/share/virtualenvs/identification-fk5tnlmm/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/madhavajay/.local/share/virtualenvs/identification-fk5tnlmm/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/madhavajay/.local/share/virtualenvs/identification-fk5tnlmm/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/madhavajay/.local/share/virtualenvs/identification-fk5tnlmm/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/madhavajay/.local/share/virtualenvs/identification-fk5tnlmm/lib/python3.7/site-packages/clean_ipynb/cli.py", line 20, in cli
    clean_ipynb(ipynb_file_path, overwrite)
  File "/Users/madhavajay/.local/share/virtualenvs/identification-fk5tnlmm/lib/python3.7/site-packages/clean_ipynb/clean_ipynb.py", line 23, in clean_ipynb
    can_clean_julia_code = has_julia_and_juliaformatter()
  File "/Users/madhavajay/.local/share/virtualenvs/identification-fk5tnlmm/lib/python3.7/site-packages/clean_ipynb/has_julia_and_juliaformatter.py", line 8, in has_julia_and_juliaformatter
    run(("julia", "--eval", "using JuliaFormatter"), check=True)
  File "/usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 472, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 1522, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'julia': 'julia'
(identification)
```