### PR TITLE
Lazy eval Julia availability.

### DIFF
--- a/clean_ipynb/clean_ipynb.py
+++ b/clean_ipynb/clean_ipynb.py
@@ -20,13 +20,11 @@ def clean_ipynb(ipynb_file_path, overwrite):
 
     language = ipynb_dict["metadata"]["language_info"]["name"]
 
-    can_clean_julia_code = has_julia_and_juliaformatter()
-
     if language == "python":
 
         clean_code = clean_python_code
 
-    elif language == "julia" and can_clean_julia_code:
+    elif language == "julia" and can_clean_julia_code():
 
         clean_code = clean_julia_code
 


### PR DESCRIPTION
Love the plugin, thanks for the work.

Ran it on a fresh env recently and pulled in your latest code, which had Julia additions that my older version didn't. When running the evals I ran into:

```
Traceback (most recent call last):
  File "/scrubbed_path_location/bin/clean_ipynb", line 11, in <module>
    load_entry_point('clean-ipynb==1.0.0', 'console_scripts', 'clean_ipynb')()
  File "/scrubbed_path_location/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/scrubbed_path_location/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/scrubbed_path_location/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/scrubbed_path_location/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/scrubbed_path_location/lib/python3.7/site-packages/clean_ipynb/cli.py", line 20, in cli
    clean_ipynb(ipynb_file_path, overwrite)
  File "/scrubbed_path_location/lib/python3.7/site-packages/clean_ipynb/clean_ipynb.py", line 26, in clean_ipynb
    can_clean_julia_code_ = can_clean_julia_code()
  File "/scrubbed_path_location/lib/python3.7/site-packages/clean_ipynb/can_clean_julia_code.py", line 8, in can_clean_julia_code
    run(("julia", "--eval", "using JuliaFormatter"), check=True)
  File "/scrubbed_path_location/versions/3.7.0/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 453, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/scrubbed_path_location/versions/3.7.0/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 756, in __init__
    restore_signals, start_new_session)
  File "/scrubbed_path_location/versions/3.7.0/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 1499, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'julia': 'julia'
```

The issue is with the eager support check for Julia. I found that interesting since I don't use an Julia code at all, all my cells are Python.

Quick fix is to lazy check only when the lang is Julia.