### PR TITLE
add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: clean_ipynb
+  name: Clean Notebooks
+  entry: clean_ipynb
+  description: Ensure that committed Jupyter notebooks contain no have imports sorted and code formatted.
+  require_serial: true
+  args: ["--overwrite"]
+  language: python
+  files: \.ipynb$
+  language_version: python3


### PR DESCRIPTION
Allow users to use this library as a git pre-commit hook through the [pre-commit framework](https://pre-commit.com/).